### PR TITLE
Single occurrence event moves to wrong date

### DIFF
--- a/swingtime/forms.py
+++ b/swingtime/forms.py
@@ -330,7 +330,7 @@ class MultipleOccurrenceForm(forms.Form):
 
     #---------------------------------------------------------------------------
     def save(self, event):
-        if self.cleaned_data['repeats'] == 'no':
+        if self.cleaned_data['repeats'] == 'count' and self.cleaned_data['count'] == 1:
             params = {}
         else:
             params = self._build_rrule_params()


### PR DESCRIPTION
We ran into a bug where a single occurrence event for any day of the week other than the current one would be moved to the current day of the week for the week the event was supposed to be created for. The problem is that self.cleaned_data['repeats'] never equals "no", so all event fall through to recurring. The default for recurring is weekly, so the single event is moved to the date as if it was a recurring event. The change uses the correct value for repeats and checks that it is a single occurrence event.

I don't really understand how this bug has not been noticed before as it shows up on any single occurrence event not created for today.