### PR TITLE
change to bulk_create to speed things up

### DIFF
--- a/swingtime/models.py
+++ b/swingtime/models.py
@@ -114,10 +114,10 @@ class Event(models.Model):
         else:
             rrule_params.setdefault('freq', rrule.DAILY)
             delta = end_time - start_time
-	    occurrences = []
+            occurrences = []
             for ev in rrule.rrule(dtstart=start_time, **rrule_params):
-		occurrences.append(Occurrence(start_time=ev, end_time=ev + delta, event=self))
-	    self.occurrence_set.bulk_create(occurrences)
+                occurrences.append(Occurrence(start_time=ev, end_time=ev + delta, event=self))
+            self.occurrence_set.bulk_create(occurrences)
 	    
     #---------------------------------------------------------------------------
     def upcoming_occurrences(self):

--- a/swingtime/models.py
+++ b/swingtime/models.py
@@ -114,9 +114,11 @@ class Event(models.Model):
         else:
             rrule_params.setdefault('freq', rrule.DAILY)
             delta = end_time - start_time
+	    occurrences = []
             for ev in rrule.rrule(dtstart=start_time, **rrule_params):
-                self.occurrence_set.create(start_time=ev, end_time=ev + delta)
-
+		occurrences.append(Occurrence(start_time=ev, end_time=ev + delta, event=self))
+	    self.occurrence_set.bulk_create(occurrences)
+	    
     #---------------------------------------------------------------------------
     def upcoming_occurrences(self):
         '''

--- a/swingtime/tests.py
+++ b/swingtime/tests.py
@@ -239,6 +239,18 @@ class CreationTest(TestCase):
         self.assertIsNotNone(e.next_occurrence())
         self.assertEqual(occs[1].title, 'This parrot has ceased to be!')
 
+    def test_6(self):
+        et = EventType.objects.create(abbr='foo', label='Foo')
+        self.assertTrue(et.abbr == 'foo')
+        
+        e = Event.objects.create(title='Yet another event', description="with tons of occurrences", event_type=et)
+        self.assertTrue(e.event_type == et)
+        self.assertEqual(e.get_absolute_url(), '/events/{}/'.format(e.id))
+        
+        e.add_occurrences(datetime(2008,1,1), datetime(2008,1,1,1),
+    			  freq=rrule.DAILY, until=datetime(2020,12,31)) # 
+        occs = list(e.occurrence_set.all())
+        self.assertEqual(len(occs), 4749)
 
 #===============================================================================
 class MiscTest(TestCase):


### PR DESCRIPTION
As the title suggests, I think we should use `bulk_create` when dealing with multiple creation

```python
    rrule_params.setdefault('freq', rrule.DAILY)
    delta = end_time - start_time
    occurrences = []
    for ev in rrule.rrule(dtstart=start_time, **rrule_params):
      occurrences.append(Occurrence(start_time=ev, end_time=ev + delta, event=self))
    self.occurrence_set.bulk_create(occurrences)
```