### PR TITLE
Provided queryset for views gets ignored if empty

### DIFF
--- a/swingtime/views.py
+++ b/swingtime/views.py
@@ -254,7 +254,7 @@ def year_view(request, year, template='swingtime/yearly_view.html', queryset=Non
         
     '''
     year = int(year)
-    queryset = queryset._clone() if queryset else Occurrence.objects.select_related()
+    queryset = queryset._clone() if queryset is not None else Occurrence.objects.select_related()
     occurrences = queryset.filter(
         models.Q(start_time__year=year) |
         models.Q(end_time__year=year)
@@ -315,7 +315,7 @@ def month_view(
 
     # TODO Whether to include those occurrences that started in the previous
     # month but end in this month?
-    queryset = queryset._clone() if queryset else Occurrence.objects.select_related()
+    queryset = queryset._clone() if queryset is not None else Occurrence.objects.select_related()
     occurrences = queryset.filter(start_time__year=year, start_time__month=month)
 
     def start_day(o):


### PR DESCRIPTION
month_view() and year_view() allow for overwriting the queryset with a custom provided one. But if the provided queryset was empty it resolved to false, thus ignoring a valid, but empty, queryset. Now the condition is more explicit, preventing this behavior.