### PR TITLE
Added support for Django 3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     platforms=['any'],
     license='MIT License',
     python_requires='>=3.5, <4',
-    install_requires=['Django>=2.0,<3.1', 'python-dateutil==2.8.0'],
+    install_requires=['Django>=2.0,<3.2', 'python-dateutil==2.8.0'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',

--- a/swingtime/__init__.py
+++ b/swingtime/__init__.py
@@ -1,4 +1,4 @@
-VERSION = (1, 1, 0)
+VERSION = (1, 1, 1)
 
 
 def get_version():

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@
 minversion=1.8.0
 envlist =
     py35-django{20,21,22}
-    py{36,37,38}-django{20,21,22,30}
+    py{36,37,38}-django{20,21,22,30,31}
 
 [testenv]
 commands = {posargs:pytest}
@@ -21,7 +21,8 @@ deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django==2.2,<3.0
-    django30: Django>=3.0b1
+    django30: Django>=3.0,<3.1
+    django31: Django>=3.1,<3.2
     coverage: Django<3.0
     pep: Django<3.0
 


### PR DESCRIPTION
It seems that Swingtime already works perfectly well with Django 3.1. All the tests pass for Python 3.5 to 3.7 and I couldn't make out any regressions through manual testing.
This pull request adds the new Django version to tox.ini and updates the package dependency, so pip won't refuse to install swingtime and django 3.1 in the same environment.